### PR TITLE
Proposal to restructure prometheus package

### DIFF
--- a/prometheus/src/main/scala/zio/metrics/prometheus2/LabelList.scala
+++ b/prometheus/src/main/scala/zio/metrics/prometheus2/LabelList.scala
@@ -1,0 +1,65 @@
+package zio.metrics.prometheus2
+
+/**
+ * A list of strings whose size is statically known.
+ *
+ * This is used to have strongly typed labelled metrics.
+ *
+ * Inspired by shapeless `HList`.
+ */
+sealed trait LabelList extends Product with Serializable {
+  def toList: List[String] = this match {
+    case LabelList.LNil              => Nil
+    case LabelList.LCons(head, tail) => head :: tail.toList
+  }
+}
+
+object LabelList {
+  case object LNil extends LabelList {
+    def ::(s: String): LCons[LNil] = LCons(s, LNil)
+  }
+  final case class LCons[+T <: LabelList](head: String, tail: T) extends LabelList {
+    def ::(s: String): LCons[LCons[T]] = LCons(s, this)
+  }
+
+  type LNil = LNil.type
+  type L0   = LNil
+  type L1   = LCons[L0]
+  type L2   = LCons[L1]
+  type L3   = LCons[L2]
+  type L4   = LCons[L3]
+  type L5   = LCons[L4]
+  type L6   = LCons[L5]
+  type L7   = LCons[L6]
+  type L8   = LCons[L7]
+  type L9   = LCons[L8]
+  type L10  = LCons[L9]
+  type L11  = LCons[L10]
+  type L12  = LCons[L11]
+  type L13  = LCons[L12]
+  type L14  = LCons[L13]
+  type L15  = LCons[L14]
+  type L16  = LCons[L15]
+  type L17  = LCons[L16]
+  type L18  = LCons[L17]
+  type L19  = LCons[L18]
+  type L20  = LCons[L19]
+  type L21  = LCons[L20]
+  type L22  = LCons[L21]
+
+  /** Returns a list the same size as `L` with the given string repeated each time. */
+  def repeat[L <: LabelList](s: String)(implicit repeat: Repeat[L]): L = repeat(s)
+
+  sealed trait Repeat[L <: LabelList] {
+    def apply(s: String): L
+  }
+  object Repeat {
+    implicit val repeatNil: Repeat[LNil] = new Repeat[LNil] {
+      def apply(s: String): LNil = LNil
+    }
+    implicit def repeatCons[T <: LabelList](implicit tail: Repeat[T]): Repeat[LCons[T]] =
+      new Repeat[LCons[T]] {
+        def apply(s: String): LCons[T] = LCons(s, tail(s))
+      }
+  }
+}

--- a/prometheus/src/main/scala/zio/metrics/prometheus2/Metric.scala
+++ b/prometheus/src/main/scala/zio/metrics/prometheus2/Metric.scala
@@ -1,0 +1,198 @@
+package zio.metrics.prometheus2
+
+import io.prometheus.{ client => jPrometheus }
+
+import zio._
+import zio.clock._
+import zio.duration.Duration
+
+trait Counter {
+  def inc: UIO[Unit] = inc(1)
+  def inc(amount: Double): UIO[Unit]
+}
+object Counter extends LabelledMetric[Registry, Throwable, Counter] {
+  def unsafeLabeled(
+    name: String,
+    help: Option[String],
+    labels: Seq[String]
+  ): ZIO[Registry, Throwable, Seq[String] => Counter] =
+    for {
+      pCounter <- updateRegistry { r =>
+                   ZIO.effect(
+                     jPrometheus.Counter
+                       .build()
+                       .name(name)
+                       .help(help.getOrElse(""))
+                       .labelNames(labels: _*)
+                       .register(r)
+                   )
+                 }
+    } yield { labels =>
+      val child = pCounter.labels(labels: _*)
+      new Counter {
+        override def inc(amount: Double): UIO[Unit] = ZIO.effectTotal(child.inc(amount))
+      }
+    }
+}
+
+trait Timer {
+
+  /** Returns how much time as elapsed since the timer was started. */
+  def elapsed: UIO[Duration]
+
+  /**
+   * Records the duration since the timer was started in the associated metric and returns that
+   * duration.
+   */
+  def stop: UIO[Duration]
+}
+
+trait TimerMetric {
+
+  /** Starts a timer. When the timer is stopped, the duration is recorded in the metric. */
+  def startTimer: UIO[Timer]
+
+  /** A managed timer resource. */
+  def timer: UManaged[Timer] = startTimer.toManaged(_.stop)
+
+  /** Runs the given effect and records in the metric how much time it took to succeed or fail. */
+  def observe[R, E, A](zio: ZIO[R, E, A]): ZIO[R, E, A] = timer.use(_ => zio)
+
+  /**
+   * Runs the given effect and records in the metric how much time it took to succeed. Do not
+   * record failures.
+   */
+  def observeSuccess[R, E, A](zio: ZIO[R, E, A]): ZIO[R, E, A] =
+    for {
+      timer <- startTimer
+      a     <- zio
+      _     <- timer.stop
+    } yield a
+
+  def observe(amount: Duration): UIO[Unit]
+}
+
+private abstract class TimerMetricImpl(clock: Clock.Service) extends TimerMetric {
+  override def startTimer: UIO[Timer] =
+    clock.instant.map { startTime =>
+      new Timer {
+        def elapsed: zio.UIO[Duration] =
+          clock.instant.map(Duration.fromInterval(startTime, _))
+        def stop: zio.UIO[Duration] =
+          elapsed.tap(observe)
+      }
+    }
+}
+
+trait Gauge extends TimerMetric {
+  def get: UIO[Double]
+  def set(value: Double): UIO[Unit]
+  def inc: UIO[Unit] = inc(1)
+  def inc(amount: Double): UIO[Unit]
+  def dec: UIO[Unit] = dec(1)
+  def dec(amount: Double): UIO[Unit]
+  override def observe(amount: Duration): UIO[Unit] = set(amount.toNanos() * 10e-9)
+}
+object Gauge extends LabelledMetric[Registry with Clock, Throwable, Gauge] {
+  def unsafeLabeled(
+    name: String,
+    help: Option[String],
+    labels: Seq[String]
+  ): ZIO[Registry with Clock, Throwable, Seq[String] => Gauge] =
+    for {
+      clock <- ZIO.service[Clock.Service]
+      pGauge <- updateRegistry { r =>
+                 ZIO.effect(
+                   jPrometheus.Gauge
+                     .build()
+                     .name(name)
+                     .help(help.getOrElse(""))
+                     .labelNames(labels: _*)
+                     .register(r)
+                 )
+               }
+    } yield { labels =>
+      val child = pGauge.labels(labels: _*)
+      new TimerMetricImpl(clock) with Gauge {
+        override def get: UIO[Double]               = ZIO.effectTotal(child.get())
+        override def set(value: Double): UIO[Unit]  = ZIO.effectTotal(child.set(value))
+        override def inc(amount: Double): UIO[Unit] = ZIO.effectTotal(child.inc(amount))
+        override def dec(amount: Double): UIO[Unit] = ZIO.effectTotal(child.dec(amount))
+      }
+    }
+}
+
+trait Buckets
+object Buckets {
+  object Default                                                    extends Buckets
+  case class Simple(buckets: Seq[Double])                           extends Buckets
+  case class Linear(start: Double, width: Double, count: Int)       extends Buckets
+  case class Exponential(start: Double, factor: Double, count: Int) extends Buckets
+}
+
+trait Histogram extends TimerMetric
+object Histogram extends LabelledMetricP[Registry with Clock, Throwable, Buckets, Histogram] {
+  def unsafeLabeled(
+    name: String,
+    buckets: Buckets,
+    help: Option[String],
+    labels: Seq[String]
+  ): ZIO[Registry with Clock, Throwable, Seq[String] => Histogram] =
+    for {
+      clock <- ZIO.service[Clock.Service]
+      pHistogram <- updateRegistry { r =>
+                     ZIO.effect {
+                       val builder = jPrometheus.Histogram
+                         .build()
+                         .name(name)
+                         .help(help.getOrElse(""))
+                         .labelNames(labels: _*)
+                       (
+                         buckets match {
+                           case Buckets.Default              => builder
+                           case Buckets.Simple(bs)           => builder.buckets(bs: _*)
+                           case Buckets.Linear(s, w, c)      => builder.linearBuckets(s, w, c)
+                           case Buckets.Exponential(s, f, c) => builder.exponentialBuckets(s, f, c)
+                         }
+                       ).register(r)
+                     }
+                   }
+    } yield { labels =>
+      val child = pHistogram.labels(labels: _*)
+      new TimerMetricImpl(clock) with Histogram {
+        override def observe(amount: Duration): UIO[Unit] =
+          ZIO.effectTotal(child.observe(amount.toNanos() * 10e-9))
+      }
+    }
+}
+
+final case class Quantile(percentile: Double, tolerance: Double)
+
+trait Summary extends TimerMetric
+object Summary extends LabelledMetricP[Registry with Clock, Throwable, List[Quantile], Summary] {
+  def unsafeLabeled(
+    name: String,
+    quantiles: List[Quantile],
+    help: Option[String],
+    labels: Seq[String]
+  ): ZIO[Registry with Clock, Throwable, Seq[String] => Summary] =
+    for {
+      clock <- ZIO.service[Clock.Service]
+      pHistogram <- updateRegistry { r =>
+                     ZIO.effect {
+                       val builder = jPrometheus.Summary
+                         .build()
+                         .name(name)
+                         .help(help.getOrElse(""))
+                         .labelNames(labels: _*)
+                       quantiles.foldLeft(builder)((b, c) => b.quantile(c.percentile, c.tolerance)).register(r)
+                     }
+                   }
+    } yield { labels =>
+      val child = pHistogram.labels(labels: _*)
+      new TimerMetricImpl(clock) with Summary {
+        override def observe(amount: Duration): UIO[Unit] =
+          ZIO.effectTotal(child.observe(amount.toNanos() * 10e-9))
+      }
+    }
+}

--- a/prometheus/src/main/scala/zio/metrics/prometheus2/example.scala
+++ b/prometheus/src/main/scala/zio/metrics/prometheus2/example.scala
@@ -1,0 +1,60 @@
+package zio.metrics.prometheus2
+
+import zio.metrics.prometheus2.LabelList._
+
+import zio._
+import zio.clock._
+
+object example {
+
+  // Case class regrouping a set of metrics
+  final case class MyMetrics(
+    counterWithoutLabels: Counter,
+    latencyWithLabels: Histogram.Labelled[L2] // `L2` captures the fact that there are 2 labels on that metric
+  )
+
+  object MyMetrics {
+    // The layer to register the metrics in the Registry
+    def live: ZLayer[Registry with Clock, Throwable, Has[MyMetrics]] =
+      ZLayer.fromEffect(
+        for {
+          counterWithoutLabels <- Counter("my_counter", Some("Counting something"))
+          latencyWithLabels <- Histogram(
+                                "my_histogram",
+                                Buckets.Default,
+                                Some("Time to do something"),
+                                "method" :: "path" :: LNil
+                              )
+        } yield MyMetrics(counterWithoutLabels, latencyWithLabels)
+      )
+  }
+
+  val app = for {
+    // Access MyMetrics from the environment
+    metrics <- ZIO.service[MyMetrics]
+
+    // Increment the counter
+    _ <- metrics.counterWithoutLabels.inc
+
+    // Start a timer, do something, record how much time it took
+    timer <- metrics.latencyWithLabels("GET" :: "/foo" :: LNil).startTimer
+    _ <- ZIO.effect {
+          // Do something
+        }
+    _ <- timer.stop
+
+    // Same as above but using `observe`. Latency is recorded even if the effect fails
+    _ <- metrics
+          .latencyWithLabels("GET" :: "/foo" :: LNil)
+          .observe(
+            ZIO.effect {
+              // Do something
+            }
+          )
+
+    // Doesn't compile because there is only one label:
+    // _ <- metrics.latencyWithLabels("GET" ::: LNil).startTimer
+  } yield ()
+
+  val runnableApp = app.provideCustomLayer((Registry.live ++ ZLayer.requires[Clock]) >>> MyMetrics.live)
+}

--- a/prometheus/src/main/scala/zio/metrics/prometheus2/exporters/package.scala
+++ b/prometheus/src/main/scala/zio/metrics/prometheus2/exporters/package.scala
@@ -1,0 +1,89 @@
+package zio.metrics.prometheus2
+
+import io.prometheus.{ client => jp }
+
+import zio._
+import zio.clock.Clock
+import zio.duration.Duration
+import java.net.InetSocketAddress
+
+package object exporters {
+
+  type Exporters = Has[Exporters.Service]
+
+  object Exporters {
+    trait Service {
+      def http(port: Int): TaskManaged[jp.exporter.HTTPServer]
+      def graphite(host: String, port: Int, interval: Duration): RManaged[Clock, Unit]
+      def pushGateway(
+        host: String,
+        port: Int,
+        jobName: String,
+        user: Option[String],
+        password: Option[String],
+        httpConnectionFactory: Option[jp.exporter.HttpConnectionFactory]
+      ): Task[Unit]
+    }
+
+    def live: URLayer[Registry, Exporters] = ZLayer.fromService { (registry: Registry.Service) =>
+      new Service {
+        def http(port: Int): TaskManaged[jp.exporter.HTTPServer] =
+          for {
+            r <- registry.collectorRegistry.toManaged_
+            server <- ZIO
+                       .effect(
+                         new jp.exporter.HTTPServer(new InetSocketAddress(port), r)
+                       )
+                       .toManaged(server => ZIO.effectTotal(server.stop()))
+          } yield server
+
+        def graphite(host: String, port: Int, interval: Duration): RManaged[Clock, Unit] =
+          for {
+            g    <- ZIO.effect(new jp.bridge.Graphite(host, port)).toManaged_
+            stop <- Ref.make(false).toManaged_
+            _ <- registry.collectorRegistry
+                  .flatMap(r => ZIO.effect(g.push(r)))
+                  .repeatOrElse(
+                    Schedule.fixed(interval) *> Schedule.recurUntilM((_: Unit) => stop.get),
+                    (_, _: Option[Unit]) => ZIO.unit
+                  )
+                  .fork
+                  .toManaged(fiber => stop.set(true) *> fiber.join)
+          } yield ()
+
+        def pushGateway(
+          host: String,
+          port: Int,
+          jobName: String,
+          user: Option[String],
+          password: Option[String],
+          httpConnectionFactory: Option[jp.exporter.HttpConnectionFactory]
+        ): Task[Unit] = registry.collectorRegistry >>= { r =>
+          ZIO.effect {
+            val pg = new jp.exporter.PushGateway(s"$host:$port")
+            (
+              for {
+                u <- user
+                p <- password
+              } yield new jp.exporter.BasicAuthHttpConnectionFactory(u, p)
+            ).orElse(httpConnectionFactory).foreach(pg.setConnectionFactory)
+            pg.pushAdd(r, jobName)
+          }
+        }
+      }
+    }
+  }
+
+  def http(port: Int): RManaged[Exporters, jp.exporter.HTTPServer] = ZManaged.accessManaged(_.get.http(port))
+  def graphite(host: String, port: Int, interval: Duration): RManaged[Exporters with Clock, Unit] =
+    ZManaged.accessManaged(_.get.graphite(host, port, interval))
+  def pushGateway(
+    host: String,
+    port: Int,
+    jobName: String,
+    user: Option[String],
+    password: Option[String],
+    httpConnectionFactory: Option[jp.exporter.HttpConnectionFactory]
+  ): RIO[Exporters, Unit] = ZIO.accessM(_.get.pushGateway(host, port, jobName, user, password, httpConnectionFactory))
+
+}

--- a/prometheus/src/main/scala/zio/metrics/prometheus2/package.scala
+++ b/prometheus/src/main/scala/zio/metrics/prometheus2/package.scala
@@ -1,0 +1,59 @@
+package zio.metrics
+
+import io.prometheus.{ client => jp }
+
+import zio._
+
+import java.io.StringWriter
+import java.{ util => ju }
+
+package object prometheus2 {
+  type Registry = Has[Registry.Service]
+
+  object Registry {
+    trait Service {
+      def collectorRegistry: UIO[jp.CollectorRegistry]
+      def updateRegistry[A](f: jp.CollectorRegistry => Task[A]): Task[A]
+      def collect: UIO[ju.Enumeration[jp.Collector.MetricFamilySamples]]
+      def string004: UIO[String] = collect >>= { sampled =>
+        ZIO.effectTotal {
+          val writer = new StringWriter
+          jp.exporter.common.TextFormat.write004(writer, sampled)
+          writer.toString
+        }
+      }
+    }
+
+    private class ServiceImpl(registry: jp.CollectorRegistry, lock: Semaphore) extends Service {
+      def collectorRegistry: UIO[jp.CollectorRegistry] = ZIO.succeed(registry)
+      def updateRegistry[A](f: jp.CollectorRegistry => zio.Task[A]): zio.Task[A] = lock.withPermit {
+        f(registry)
+      }
+      def collect: zio.UIO[ju.Enumeration[jp.Collector.MetricFamilySamples]] =
+        ZIO.effectTotal(registry.metricFamilySamples())
+    }
+
+    def live: ULayer[Registry] = ZLayer.fromEffect(
+      Semaphore.make(1).map(new ServiceImpl(new jp.CollectorRegistry(), _))
+    )
+
+    def default: ULayer[Registry] = ZLayer.fromEffect(
+      Semaphore.make(1).map(new ServiceImpl(jp.CollectorRegistry.defaultRegistry, _))
+    )
+
+    def defaultMetrics: ZLayer[Registry, Throwable, Registry] = ZLayer.fromServiceM { registry =>
+      registry.updateRegistry(r => ZIO.effect(jp.hotspot.DefaultExports.register(r))).as(registry)
+    }
+
+    def liveWithDefaultMetrics: TaskLayer[Registry] = live >>> defaultMetrics
+  }
+
+  def collectorRegistry: RIO[Registry, jp.CollectorRegistry] =
+    ZIO.accessM(_.get.collectorRegistry)
+  def updateRegistry[A](f: jp.CollectorRegistry => Task[A]): RIO[Registry, A] =
+    ZIO.accessM(_.get.updateRegistry(f))
+  def collect: RIO[Registry, ju.Enumeration[jp.Collector.MetricFamilySamples]] =
+    ZIO.accessM(_.get.collect)
+  def string004: RIO[Registry, String] =
+    ZIO.accessM(_.get.string004)
+}


### PR DESCRIPTION
- Use statically typed LabelList to ensure that the right number of labels are passed.
  I found myself caught by that one a few time using the Prometheus Java library. (This is especially sneaky when you haven't specified the right set of labels on a metric that is used to count applicative errors. Not only the counter is never incremented so in Grafana it says "No error", but also the exception thrown by Prometheus hides the real applicative error)
- Use ZIO Clock for all timing operations
- Use a semaphore to protect access to the `CollectorRegistry` a ZRef doesn't work to protect concurrent access to mutable data.
   From [ZRef doc](https://javadoc.io/doc/dev.zio/zio_2.12/latest/zio/ZRef.html):
   > NOTE: While ZRef provides the functional equivalent of a mutable reference, the value inside the ZRef should be immutable. For performance reasons ZRef is implemented in terms of compare and swap operations rather than synchronization. These operations are not safe for mutable values that do not support concurrent access.

See `example.scala` for usage examples

If you think that approach is worth pursuing, I can dig a bit deeper to figure out how to smoothly integrate it with the existing code base.