### PR TITLE
Removing ref from Registry.Service Impl

### DIFF
--- a/prometheus/src/main/scala/zio/metrics/prometheus/package.scala
+++ b/prometheus/src/main/scala/zio/metrics/prometheus/package.scala
@@ -26,7 +26,6 @@ package object prometheus {
     type Percentile = Double
     type Tolerance  = Double
 
-
     val explicit: ZLayer[Has[CollectorRegistry], Nothing, Registry] =
       ZLayer.fromService[CollectorRegistry, Registry.Service](
         registry =>
@@ -35,42 +34,42 @@ package object prometheus {
             def getCurrent(): UIO[CollectorRegistry] = UIO(registry)
 
             def registerCounter[A: Show](label: Label[A]): Task[PCounter] =
-                Task({
-                  val name = Show[A].show(label.name)
-                  PCounter
-                    .build()
-                    .name(name)
-                    .labelNames(label.labels: _*)
-                    .help(label.help)
-                    .register(registry)
-                })
+              Task({
+                val name = Show[A].show(label.name)
+                PCounter
+                  .build()
+                  .name(name)
+                  .labelNames(label.labels: _*)
+                  .help(label.help)
+                  .register(registry)
+              })
 
             def registerGauge[L: Show](label: Label[L]): Task[PGauge] =
-                Task({
-                  val name = Show[L].show(label.name)
-                  PGauge
-                    .build()
-                    .name(name)
-                    .labelNames(label.labels: _*)
-                    .help(label.help)
-                    .register(registry)
-                })
+              Task({
+                val name = Show[L].show(label.name)
+                PGauge
+                  .build()
+                  .name(name)
+                  .labelNames(label.labels: _*)
+                  .help(label.help)
+                  .register(registry)
+              })
 
             def registerHistogram[L: Show](label: Label[L], buckets: Buckets): Task[PHistogram] =
-                Task({
-                  val name = Show[L].show(label.name)
-                  val hb = PHistogram
-                    .build()
-                    .name(name)
-                    .labelNames(label.labels: _*)
-                    .help(label.help)
+              Task({
+                val name = Show[L].show(label.name)
+                val hb = PHistogram
+                  .build()
+                  .name(name)
+                  .labelNames(label.labels: _*)
+                  .help(label.help)
 
-                  val h = buckets match {
-                    case DefaultBuckets(bs)          => if (bs.isEmpty) hb else hb.buckets(bs: _*)
-                    case LinearBuckets(s, w, c)      => hb.linearBuckets(s, w, c)
-                    case ExponentialBuckets(s, f, c) => hb.exponentialBuckets(s, f, c)
-                  }
-                  h.register(registry)
+                val h = buckets match {
+                  case DefaultBuckets(bs)          => if (bs.isEmpty) hb else hb.buckets(bs: _*)
+                  case LinearBuckets(s, w, c)      => hb.linearBuckets(s, w, c)
+                  case ExponentialBuckets(s, f, c) => hb.exponentialBuckets(s, f, c)
+                }
+                h.register(registry)
               })
 
             def registerSummary[L: Show](label: Label[L], quantiles: List[(Percentile, Tolerance)]): Task[PSummary] =
@@ -87,7 +86,8 @@ package object prometheus {
           }
       )
 
-    val live: ZLayer[Any, Nothing, Has[Registry.Service]] = ZLayer.succeed(CollectorRegistry.defaultRegistry) >>> explicit
+    val live
+      : ZLayer[Any, Nothing, Has[Registry.Service]] = ZLayer.succeed(CollectorRegistry.defaultRegistry) >>> explicit
 
   }
 }

--- a/prometheus/src/main/scala/zio/metrics/prometheus/package.scala
+++ b/prometheus/src/main/scala/zio/metrics/prometheus/package.scala
@@ -1,7 +1,7 @@
 package zio.metrics
 
 import zio.{ Has, ZLayer }
-import zio.{ Ref, Task, UIO }
+import zio.{ Task, UIO }
 
 package object prometheus {
 
@@ -26,60 +26,55 @@ package object prometheus {
     type Percentile = Double
     type Tolerance  = Double
 
-    val explicit: ZLayer[Has[Option[CollectorRegistry]], Nothing, Registry] =
-      ZLayer.fromFunction[Has[Option[CollectorRegistry]], Registry.Service](
-        optionalRegistry =>
-          new Service {
-            private val registryRef: UIO[Ref[CollectorRegistry]] = {
-              val registry = optionalRegistry.get
-              Ref.make(registry.getOrElse(CollectorRegistry.defaultRegistry))
-            }
 
-            def getCurrent(): UIO[CollectorRegistry] = registryRef >>= (_.get)
+    val explicit: ZLayer[Has[CollectorRegistry], Nothing, Registry] =
+      ZLayer.fromService[CollectorRegistry, Registry.Service](
+        registry =>
+          new Service {
+
+            def getCurrent(): UIO[CollectorRegistry] = UIO(registry)
 
             def registerCounter[A: Show](label: Label[A]): Task[PCounter] =
-              registryRef >>= (_.modify(r => {
-                val name = Show[A].show(label.name)
-                val c = PCounter
-                  .build()
-                  .name(name)
-                  .labelNames(label.labels: _*)
-                  .help(label.help)
-                  .register(r)
-                (c, r)
-              }))
+                Task({
+                  val name = Show[A].show(label.name)
+                  PCounter
+                    .build()
+                    .name(name)
+                    .labelNames(label.labels: _*)
+                    .help(label.help)
+                    .register(registry)
+                })
 
             def registerGauge[L: Show](label: Label[L]): Task[PGauge] =
-              registryRef >>= (_.modify(r => {
-                val name = Show[L].show(label.name)
-                val g = PGauge
-                  .build()
-                  .name(name)
-                  .labelNames(label.labels: _*)
-                  .help(label.help)
-                  .register(r)
-                (g, r)
-              }))
+                Task({
+                  val name = Show[L].show(label.name)
+                  PGauge
+                    .build()
+                    .name(name)
+                    .labelNames(label.labels: _*)
+                    .help(label.help)
+                    .register(registry)
+                })
 
             def registerHistogram[L: Show](label: Label[L], buckets: Buckets): Task[PHistogram] =
-              registryRef >>= (_.modify(r => {
-                val name = Show[L].show(label.name)
-                val hb = PHistogram
-                  .build()
-                  .name(name)
-                  .labelNames(label.labels: _*)
-                  .help(label.help)
+                Task({
+                  val name = Show[L].show(label.name)
+                  val hb = PHistogram
+                    .build()
+                    .name(name)
+                    .labelNames(label.labels: _*)
+                    .help(label.help)
 
-                val h = buckets match {
-                  case DefaultBuckets(bs)          => if (bs.isEmpty) hb else hb.buckets(bs: _*)
-                  case LinearBuckets(s, w, c)      => hb.linearBuckets(s, w, c)
-                  case ExponentialBuckets(s, f, c) => hb.exponentialBuckets(s, f, c)
-                }
-                (h.register(r), r)
-              }))
+                  val h = buckets match {
+                    case DefaultBuckets(bs)          => if (bs.isEmpty) hb else hb.buckets(bs: _*)
+                    case LinearBuckets(s, w, c)      => hb.linearBuckets(s, w, c)
+                    case ExponentialBuckets(s, f, c) => hb.exponentialBuckets(s, f, c)
+                  }
+                  h.register(registry)
+              })
 
             def registerSummary[L: Show](label: Label[L], quantiles: List[(Percentile, Tolerance)]): Task[PSummary] =
-              registryRef >>= (_.modify(r => {
+              Task({
                 val name = Show[L].show(label.name)
                 val sb = PSummary
                   .build()
@@ -87,13 +82,12 @@ package object prometheus {
                   .labelNames(label.labels: _*)
                   .help(label.help)
 
-                val s = quantiles.foldLeft(sb)((acc, c) => acc.quantile(c._1, c._2)).register(r)
-                (s, r)
-              }))
+                quantiles.foldLeft(sb)((acc, c) => acc.quantile(c._1, c._2)).register(registry)
+              })
           }
       )
 
-    val live: ZLayer[Any, Nothing, Has[Registry.Service]] = ZLayer.succeed[Option[CollectorRegistry]](None) >>> explicit
+    val live: ZLayer[Any, Nothing, Has[Registry.Service]] = ZLayer.succeed(CollectorRegistry.defaultRegistry) >>> explicit
 
   }
 }

--- a/prometheus/src/test/scala/zio/metrics/ExplicitRegistryLayer.scala
+++ b/prometheus/src/test/scala/zio/metrics/ExplicitRegistryLayer.scala
@@ -22,7 +22,7 @@ object ExplicitRegistryLayer {
     .register(myRegistry)
   preCounter.inc(9)
 
-  val myCustomLayer = ZLayer.succeed[Option[CollectorRegistry]](Some(myRegistry)) >>> Registry.explicit
+  val myCustomLayer = ZLayer.succeed(myRegistry) >>> Registry.explicit
 
   val rt = Runtime.unsafeFromLayer(MetricMap.live ++ Exporters.live ++ Console.live)
 


### PR DESCRIPTION
This started as my attempt to fix #108. I originally was just going to update the `Ref[CollectionRegistry]` to a `RefM`. But, after looking at the code, I don't think that a Ref makes sense for this use case. My understanding is that Refs are intended to be used with immutable objects. The CollectorRegistry is mutable, and the default registry is a global static variable anyways. Given that, I think it's best just to wrap all the calls to the registry in an effect and leave it at that.