### PR TITLE
Correct spelling to 'Labelled'

### DIFF
--- a/docs/essentials/dropwizard.md
+++ b/docs/essentials/dropwizard.md
@@ -119,7 +119,7 @@ passed as a parameter along with optional labels.
 Or with labels:
 
 ```scala mdoc:silent
-  val testLabeledCounter: RIO[Registry, MetricRegistry] = for {
+  val testLabelledCounter: RIO[Registry, MetricRegistry] = for {
     c   <- counter.register("DropwizardCounterHelper", Array("test", "counter"))
     _   <- c.inc()
     _   <- c.inc(2.0)

--- a/docs/essentials/prometheus.md
+++ b/docs/essentials/prometheus.md
@@ -125,8 +125,8 @@ If the counter is registered with labels, then you need to increase the counter
   passing the same number of labels when registered.
 
 ```scala mdoc:silent
-  val testLabeledCounter: RIO[Registry, CollectorRegistry] = for {
-    c  <- Counter("simple_counter_labeled", Array("method", "resource"))
+  val testLabelledCounter: RIO[Registry, CollectorRegistry] = for {
+    c  <- Counter("simple_counter_labelled", Array("method", "resource"))
     _  <- c.inc(Array("get", "users"))
     _  <- c.inc(2.0, Array("get", "users"))
     r  <- getCurrentRegistry()
@@ -205,7 +205,7 @@ method](https://github.com/zio/zio-metrics/blob/master/prometheus/src/main/scala
 With labels it looks like this:
 
 ```scala mdoc:silent
-  val testLabeledGauge: RIO[Registry, (CollectorRegistry, Double)] = for {
+  val testLabelledGauge: RIO[Registry, (CollectorRegistry, Double)] = for {
     g  <- Gauge("simple_gauge", Array("method"))
     _  <- g.inc(Array("get"))
     _  <- g.inc(2.0, Array("get"))

--- a/prometheus/src/main/scala/zio/metrics/prometheus2/Labelled.scala
+++ b/prometheus/src/main/scala/zio/metrics/prometheus2/Labelled.scala
@@ -10,16 +10,16 @@ import zio.ZIO
  * values with the same length.
  */
 trait LabelledMetric[R, E, M] {
-  def unsafeLabeled(
+  def unsafeLabelled(
     name: String,
     help: Option[String],
     labels: Seq[String]
   ): ZIO[R, E, Seq[String] => M]
 
   def apply(name: String, help: Option[String]): ZIO[R, E, M] =
-    unsafeLabeled(name, help, Nil).map(f => f(Nil))
+    unsafeLabelled(name, help, Nil).map(f => f(Nil))
   def apply[L <: LabelList](name: String, help: Option[String], labels: L): ZIO[R, E, Labelled[L]] =
-    unsafeLabeled(name, help, labels.toList).map(f => (l: L) => f(l.toList))
+    unsafeLabelled(name, help, labels.toList).map(f => (l: L) => f(l.toList))
 
   type Labelled[L <: LabelList] = L => M
 }
@@ -32,7 +32,7 @@ trait LabelledMetric[R, E, M] {
  * values with the same length.
  */
 trait LabelledMetricP[R, E, P, M] {
-  protected[this] def unsafeLabeled(
+  protected[this] def unsafeLabelled(
     name: String,
     p: P,
     help: Option[String],
@@ -40,14 +40,14 @@ trait LabelledMetricP[R, E, P, M] {
   ): ZIO[R, E, Seq[String] => M]
 
   def apply(name: String, p: P, help: Option[String]): ZIO[R, E, M] =
-    unsafeLabeled(name, p, help, Nil).map(f => f(Nil))
+    unsafeLabelled(name, p, help, Nil).map(f => f(Nil))
   def apply[L <: LabelList](
     name: String,
     p: P,
     help: Option[String],
     labels: L
   ): ZIO[R, E, Labelled[L]] =
-    unsafeLabeled(name, p, help, labels.toList).map(f => (l: L) => f(l.toList))
+    unsafeLabelled(name, p, help, labels.toList).map(f => (l: L) => f(l.toList))
 
   type Labelled[L <: LabelList] = L => M
 }

--- a/prometheus/src/main/scala/zio/metrics/prometheus2/Metric.scala
+++ b/prometheus/src/main/scala/zio/metrics/prometheus2/Metric.scala
@@ -10,7 +10,7 @@ trait Counter {
   def inc(amount: Double): UIO[Unit]
 }
 object Counter extends LabelledMetric[Registry, Throwable, Counter] {
-  def unsafeLabeled(
+  def unsafeLabelled(
     name: String,
     help: Option[String],
     labels: Seq[String]
@@ -93,7 +93,7 @@ trait Gauge extends TimerMetric {
   override def observe(amount: Duration): UIO[Unit] = set(amount.toNanos() * 1e-9)
 }
 object Gauge extends LabelledMetric[Registry with Clock, Throwable, Gauge] {
-  def unsafeLabeled(
+  def unsafeLabelled(
     name: String,
     help: Option[String],
     labels: Seq[String]
@@ -131,7 +131,7 @@ object Buckets {
 
 trait Histogram extends TimerMetric
 object Histogram extends LabelledMetricP[Registry with Clock, Throwable, Buckets, Histogram] {
-  def unsafeLabeled(
+  def unsafeLabelled(
     name: String,
     buckets: Buckets,
     help: Option[String],
@@ -169,7 +169,7 @@ final case class Quantile(percentile: Double, tolerance: Double)
 
 trait Summary extends TimerMetric
 object Summary extends LabelledMetricP[Registry with Clock, Throwable, List[Quantile], Summary] {
-  def unsafeLabeled(
+  def unsafeLabelled(
     name: String,
     quantiles: List[Quantile],
     help: Option[String],


### PR DESCRIPTION
Current code and docs use a mix of 'Labeled' and 'Labelled'. This PR is for the zio2 branch - to standardise on 'Labelled'.