### PR TITLE
Upgrade interop cats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,8 @@ run / fork := true
 
 val http4sVersion     = "0.23.11"
 val zioVersion        = "2.0.0-RC5"
-val interopVersion    = "3.3.0-RC5"
-val catsEffectVersion = "3.3.9"
+val interopVersion    = "3.3.0-RC6"
+val catsEffectVersion = "3.3.11"
 //val zioNIOVersion     = "1.0.0-RC11"
 val prometheusVersion = "0.12.0"
 val dropwizardVersion = "4.2.0"


### PR DESCRIPTION
This fixes the hanging tests in my testing. We ran into a similar issue while upgrading Tapir that required a fix to interop-cats:

    - https://github.com/softwaremill/tapir/pull/2043
    - https://github.com/zio/interop-cats/issues/533
